### PR TITLE
separate point lights map

### DIFF
--- a/src/Open4Es-Chocapic/shaders/world0/gbuffers_terrain.fsh
+++ b/src/Open4Es-Chocapic/shaders/world0/gbuffers_terrain.fsh
@@ -13,7 +13,30 @@ const int noiseTextureResolution = 256;
 
 /* DRAWBUFFERS:0 */
 void main() {
-	gl_FragData[0] = texture2D(texture, texcoord.st) * texture2D(lightmap, lmcoord.st) * color;
+
+	vec3 pointLightsTint = vec3(1.0, 0.6, 0.25);
+	float pointLightsMap = lmcoord.x;
+	
+	float pointLightsBright = pow(pointLightsMap, 24.0) * 48.0;
+	pointLightsBright = clamp(pointLightsBright, 0.0, 4.0);
+	
+	float pointLightsDark = pow(pointLightsMap, 1.0) * 1.0;	
+	vec3 pointLights = pointLightsTint * (pointLightsBright + pointLightsDark);
+
+	vec3 ambientLight = texture2D(lightmap, vec2(0, lmcoord.y)).rgb;
+
+	vec3 resultLighting = ambientLight + pointLights;
+
+
+
+	vec4 diffuse = texture2D(texture, texcoord.xy);
+	diffuse *= color;
+	diffuse *= vec4(resultLighting, 1.0);
+
+
+	gl_FragData[0] = diffuse;
+ 
+ 
 	if(fogMode == 9729)
 		gl_FragData[0].rgb = mix(gl_Fog.color.rgb, gl_FragData[0].rgb, clamp((gl_Fog.end - gl_FogFragCoord) / (gl_Fog.end - gl_Fog.start), 0.0, 1.0));
 	else if(fogMode == 2048)


### PR DESCRIPTION
now it is possible to control color of torches/lamps/lava separately from ambient light
 - boosted light intencity near light sources
![image](https://user-images.githubusercontent.com/40975486/121673878-33bf0900-cad3-11eb-82c4-a487d1ad93d6.png)
